### PR TITLE
Create GitLab API tool for projects and MRs

### DIFF
--- a/gitlab-api-tool/.gitignore
+++ b/gitlab-api-tool/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+*.log
+.env
+.env.local

--- a/gitlab-api-tool/README.md
+++ b/gitlab-api-tool/README.md
@@ -1,0 +1,160 @@
+# GitLab API Tool
+
+GitLab Web APIを使用してプロジェクト一覧やマージリクエスト一覧を取得するCLIツールです。
+
+## インストール
+
+```bash
+npm install
+npm run build
+```
+
+## 環境変数の設定
+
+以下の環境変数を設定してください：
+
+```bash
+export GITLAB_URL="https://gitlab.com"  # GitLabインスタンスのURL
+export GITLAB_TOKEN="your-personal-access-token"  # GitLab Personal Access Token
+```
+
+Personal Access Tokenの取得方法：
+1. GitLabの Settings > Access Tokens にアクセス
+2. 新しいトークンを作成（スコープ: `read_api` が必要）
+
+## 使用方法
+
+### プロジェクト一覧の取得
+
+```bash
+# 基本的な使い方
+npm run dev -- projects
+
+# 自分が所有するプロジェクトのみ
+npm run dev -- projects --owned
+
+# メンバーとして参加しているプロジェクト
+npm run dev -- projects --membership
+
+# プロジェクト名で検索
+npm run dev -- projects --search "my-project"
+
+# 可視性でフィルタ
+npm run dev -- projects --visibility private
+
+# JSON形式で出力
+npm run dev -- projects --json
+
+# ページネーション
+npm run dev -- projects --per-page 50 --page 2
+```
+
+### マージリクエスト一覧の取得
+
+```bash
+# 基本的な使い方（オープン状態のMRを取得）
+npm run dev -- merge-requests
+# または短縮形
+npm run dev -- mrs
+
+# 特定のプロジェクトのMR
+npm run dev -- mrs -p my-group/my-project
+
+# 状態でフィルタ（opened, closed, merged, locked, all）
+npm run dev -- mrs --state all
+npm run dev -- mrs --state merged
+
+# 自分に割り当てられたMR
+npm run dev -- mrs --scope assigned_to_me
+
+# 自分が作成したMR
+npm run dev -- mrs --scope created_by_me
+
+# タイトル・説明で検索
+npm run dev -- mrs --search "feature"
+
+# ラベルでフィルタ
+npm run dev -- mrs --labels "bug,urgent"
+
+# 日付でフィルタ
+npm run dev -- mrs --created-after "2024-01-01"
+npm run dev -- mrs --updated-after "2024-06-01"
+
+# JSON形式で出力
+npm run dev -- mrs --json
+```
+
+## CLIオプション
+
+### projects コマンド
+
+| オプション | 説明 |
+|------------|------|
+| `--owned` | 自分が所有するプロジェクトのみ |
+| `--membership` | メンバーとして参加しているプロジェクト |
+| `--starred` | スター付きプロジェクト |
+| `-s, --search <query>` | 名前で検索 |
+| `-v, --visibility <type>` | 可視性フィルタ (private/internal/public) |
+| `--archived` | アーカイブされたプロジェクトを含む |
+| `--order-by <field>` | ソートフィールド |
+| `--sort <direction>` | ソート順 (asc/desc) |
+| `--per-page <count>` | 1ページあたりの件数 (デフォルト: 20) |
+| `--page <number>` | ページ番号 (デフォルト: 1) |
+| `--json` | JSON形式で出力 |
+
+### merge-requests (mrs) コマンド
+
+| オプション | 説明 |
+|------------|------|
+| `-p, --project <id>` | プロジェクトID またはパス |
+| `--state <state>` | 状態フィルタ (opened/closed/merged/locked/all) |
+| `--scope <scope>` | スコープ (created_by_me/assigned_to_me/all) |
+| `--author-id <id>` | 作成者IDでフィルタ |
+| `--assignee-id <id>` | 担当者IDでフィルタ |
+| `--reviewer-id <id>` | レビュアーIDでフィルタ |
+| `-s, --search <query>` | タイトル・説明で検索 |
+| `-l, --labels <labels>` | ラベルでフィルタ (カンマ区切り) |
+| `--created-after <date>` | 作成日でフィルタ (ISO 8601形式) |
+| `--created-before <date>` | 作成日でフィルタ (ISO 8601形式) |
+| `--updated-after <date>` | 更新日でフィルタ (ISO 8601形式) |
+| `--updated-before <date>` | 更新日でフィルタ (ISO 8601形式) |
+| `--order-by <field>` | ソートフィールド (created_at/updated_at) |
+| `--sort <direction>` | ソート順 (asc/desc) |
+| `--per-page <count>` | 1ページあたりの件数 (デフォルト: 20) |
+| `--page <number>` | ページ番号 (デフォルト: 1) |
+| `--json` | JSON形式で出力 |
+
+## ライブラリとしての使用
+
+このツールはライブラリとしても使用できます：
+
+```typescript
+import { GitLabClient } from 'gitlab-api-tool';
+
+const client = new GitLabClient({
+  baseUrl: 'https://gitlab.com',
+  privateToken: 'your-token',
+});
+
+// プロジェクト一覧を取得
+const projects = await client.listProjects({
+  owned: true,
+  perPage: 50,
+});
+
+// マージリクエスト一覧を取得
+const mergeRequests = await client.listMergeRequests({
+  projectId: 'my-group/my-project',
+  state: 'opened',
+});
+
+// 特定のプロジェクトを取得
+const project = await client.getProject('my-group/my-project');
+
+// 特定のマージリクエストを取得
+const mr = await client.getMergeRequest('my-group/my-project', 123);
+```
+
+## ライセンス
+
+MIT

--- a/gitlab-api-tool/package-lock.json
+++ b/gitlab-api-tool/package-lock.json
@@ -1,0 +1,606 @@
+{
+  "name": "gitlab-api-tool",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gitlab-api-tool",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "gitlab-tool": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.6.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
+      "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.2",
+        "@esbuild/android-arm": "0.27.2",
+        "@esbuild/android-arm64": "0.27.2",
+        "@esbuild/android-x64": "0.27.2",
+        "@esbuild/darwin-arm64": "0.27.2",
+        "@esbuild/darwin-x64": "0.27.2",
+        "@esbuild/freebsd-arm64": "0.27.2",
+        "@esbuild/freebsd-x64": "0.27.2",
+        "@esbuild/linux-arm": "0.27.2",
+        "@esbuild/linux-arm64": "0.27.2",
+        "@esbuild/linux-ia32": "0.27.2",
+        "@esbuild/linux-loong64": "0.27.2",
+        "@esbuild/linux-mips64el": "0.27.2",
+        "@esbuild/linux-ppc64": "0.27.2",
+        "@esbuild/linux-riscv64": "0.27.2",
+        "@esbuild/linux-s390x": "0.27.2",
+        "@esbuild/linux-x64": "0.27.2",
+        "@esbuild/netbsd-arm64": "0.27.2",
+        "@esbuild/netbsd-x64": "0.27.2",
+        "@esbuild/openbsd-arm64": "0.27.2",
+        "@esbuild/openbsd-x64": "0.27.2",
+        "@esbuild/openharmony-arm64": "0.27.2",
+        "@esbuild/sunos-x64": "0.27.2",
+        "@esbuild/win32-arm64": "0.27.2",
+        "@esbuild/win32-ia32": "0.27.2",
+        "@esbuild/win32-x64": "0.27.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/gitlab-api-tool/package.json
+++ b/gitlab-api-tool/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "gitlab-api-tool",
+  "version": "1.0.0",
+  "description": "CLI tool to interact with GitLab API - fetch projects and merge requests",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "gitlab-tool": "dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/cli.js",
+    "dev": "tsx src/cli.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "gitlab",
+    "api",
+    "cli",
+    "merge-request",
+    "projects"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "commander": "^12.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/gitlab-api-tool/src/cli.ts
+++ b/gitlab-api-tool/src/cli.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+/**
+ * GitLab API Tool CLI
+ */
+
+import { Command } from "commander";
+import { registerProjectsCommand, registerMergeRequestsCommand } from "./commands/index.js";
+
+const program = new Command();
+
+program
+  .name("gitlab-tool")
+  .description("CLI tool to interact with GitLab API")
+  .version("1.0.0");
+
+// Register commands
+registerProjectsCommand(program);
+registerMergeRequestsCommand(program);
+
+// Add help text about environment variables
+program.addHelpText(
+  "after",
+  `
+Environment Variables:
+  GITLAB_URL     GitLab instance URL (e.g., https://gitlab.com)
+  GITLAB_TOKEN   GitLab personal access token
+
+Examples:
+  $ gitlab-tool projects --owned
+  $ gitlab-tool projects --search "my-project"
+  $ gitlab-tool merge-requests --state opened
+  $ gitlab-tool mrs -p my-group/my-project --state all
+  $ gitlab-tool mrs --scope assigned_to_me
+`
+);
+
+program.parse();

--- a/gitlab-api-tool/src/client/index.ts
+++ b/gitlab-api-tool/src/client/index.ts
@@ -1,0 +1,145 @@
+/**
+ * GitLab API Client
+ */
+
+import type {
+  GitLabConfig,
+  GitLabProject,
+  GitLabMergeRequest,
+  ProjectListOptions,
+  MergeRequestListOptions,
+} from "../types/index.js";
+
+export class GitLabClient {
+  private baseUrl: string;
+  private privateToken: string;
+
+  constructor(config: GitLabConfig) {
+    this.baseUrl = config.baseUrl.replace(/\/$/, "");
+    this.privateToken = config.privateToken;
+  }
+
+  private async request<T>(
+    endpoint: string,
+    params: Record<string, string | number | boolean | undefined> = {}
+  ): Promise<T> {
+    const url = new URL(`${this.baseUrl}/api/v4${endpoint}`);
+
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined) {
+        url.searchParams.append(this.toSnakeCase(key), String(value));
+      }
+    });
+
+    const response = await fetch(url.toString(), {
+      headers: {
+        "PRIVATE-TOKEN": this.privateToken,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `GitLab API Error: ${response.status} ${response.statusText} - ${errorText}`
+      );
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  private toSnakeCase(str: string): string {
+    return str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+  }
+
+  /**
+   * Get list of projects
+   */
+  async listProjects(options: ProjectListOptions = {}): Promise<GitLabProject[]> {
+    return this.request<GitLabProject[]>("/projects", {
+      owned: options.owned,
+      membership: options.membership,
+      starred: options.starred,
+      search: options.search,
+      visibility: options.visibility,
+      archived: options.archived,
+      orderBy: options.orderBy,
+      sort: options.sort,
+      perPage: options.perPage ?? 20,
+      page: options.page ?? 1,
+    });
+  }
+
+  /**
+   * Get a single project by ID or path
+   */
+  async getProject(projectId: number | string): Promise<GitLabProject> {
+    const encodedId =
+      typeof projectId === "string" ? encodeURIComponent(projectId) : projectId;
+    return this.request<GitLabProject>(`/projects/${encodedId}`);
+  }
+
+  /**
+   * Get list of merge requests
+   * If projectId is provided, returns MRs for that project only
+   */
+  async listMergeRequests(
+    options: MergeRequestListOptions = {}
+  ): Promise<GitLabMergeRequest[]> {
+    const { projectId, ...otherOptions } = options;
+
+    const endpoint = projectId
+      ? `/projects/${encodeURIComponent(projectId)}/merge_requests`
+      : "/merge_requests";
+
+    return this.request<GitLabMergeRequest[]>(endpoint, {
+      state: otherOptions.state ?? "opened",
+      scope: otherOptions.scope,
+      authorId: otherOptions.authorId,
+      assigneeId: otherOptions.assigneeId,
+      reviewerId: otherOptions.reviewerId,
+      search: otherOptions.search,
+      labels: otherOptions.labels?.join(","),
+      createdAfter: otherOptions.createdAfter,
+      createdBefore: otherOptions.createdBefore,
+      updatedAfter: otherOptions.updatedAfter,
+      updatedBefore: otherOptions.updatedBefore,
+      orderBy: otherOptions.orderBy,
+      sort: otherOptions.sort,
+      perPage: otherOptions.perPage ?? 20,
+      page: otherOptions.page ?? 1,
+    });
+  }
+
+  /**
+   * Get a single merge request
+   */
+  async getMergeRequest(
+    projectId: number | string,
+    mrIid: number
+  ): Promise<GitLabMergeRequest> {
+    const encodedProjectId =
+      typeof projectId === "string" ? encodeURIComponent(projectId) : projectId;
+    return this.request<GitLabMergeRequest>(
+      `/projects/${encodedProjectId}/merge_requests/${mrIid}`
+    );
+  }
+}
+
+/**
+ * Create a GitLab client from environment variables
+ */
+export function createClientFromEnv(): GitLabClient {
+  const baseUrl = process.env.GITLAB_URL;
+  const privateToken = process.env.GITLAB_TOKEN;
+
+  if (!baseUrl) {
+    throw new Error("GITLAB_URL environment variable is required");
+  }
+
+  if (!privateToken) {
+    throw new Error("GITLAB_TOKEN environment variable is required");
+  }
+
+  return new GitLabClient({ baseUrl, privateToken });
+}

--- a/gitlab-api-tool/src/commands/index.ts
+++ b/gitlab-api-tool/src/commands/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Commands Index
+ */
+
+export { registerProjectsCommand } from "./projects.js";
+export { registerMergeRequestsCommand } from "./merge-requests.js";

--- a/gitlab-api-tool/src/commands/merge-requests.ts
+++ b/gitlab-api-tool/src/commands/merge-requests.ts
@@ -1,0 +1,149 @@
+/**
+ * Merge Requests Command
+ */
+
+import type { Command } from "commander";
+import { createClientFromEnv } from "../client/index.js";
+import type { MergeRequestListOptions, GitLabMergeRequest } from "../types/index.js";
+
+interface MergeRequestsCommandOptions {
+  project?: string;
+  state?: "opened" | "closed" | "merged" | "locked" | "all";
+  scope?: "created_by_me" | "assigned_to_me" | "all";
+  authorId?: string;
+  assigneeId?: string;
+  reviewerId?: string;
+  search?: string;
+  labels?: string;
+  createdAfter?: string;
+  createdBefore?: string;
+  updatedAfter?: string;
+  updatedBefore?: string;
+  orderBy?: string;
+  sort?: "asc" | "desc";
+  perPage?: string;
+  page?: string;
+  json?: boolean;
+}
+
+function formatMergeRequest(mr: GitLabMergeRequest): string {
+  const stateEmoji = {
+    opened: "🟢",
+    closed: "🔴",
+    merged: "🟣",
+    locked: "🔒",
+  }[mr.state];
+
+  const lines = [
+    `ID: ${mr.id} | IID: !${mr.iid}`,
+    `Title: ${mr.draft ? "[Draft] " : ""}${mr.title}`,
+    `State: ${stateEmoji} ${mr.state}`,
+    `Branch: ${mr.source_branch} → ${mr.target_branch}`,
+    `URL: ${mr.web_url}`,
+    `Author: ${mr.author.name} (@${mr.author.username})`,
+    `Assignee: ${mr.assignee ? `${mr.assignee.name} (@${mr.assignee.username})` : "(none)"}`,
+    `Reviewers: ${mr.reviewers.length > 0 ? mr.reviewers.map((r) => `@${r.username}`).join(", ") : "(none)"}`,
+    `Labels: ${mr.labels.length > 0 ? mr.labels.join(", ") : "(none)"}`,
+    `Has Conflicts: ${mr.has_conflicts ? "Yes ⚠️" : "No"}`,
+    `Created: ${mr.created_at}`,
+    `Updated: ${mr.updated_at}`,
+  ];
+
+  if (mr.merged_at) {
+    lines.push(`Merged: ${mr.merged_at}`);
+  }
+  if (mr.closed_at) {
+    lines.push(`Closed: ${mr.closed_at}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function registerMergeRequestsCommand(program: Command): void {
+  program
+    .command("merge-requests")
+    .alias("mrs")
+    .description("List GitLab merge requests")
+    .option("-p, --project <id>", "Project ID or path (e.g., 'group/project')")
+    .option(
+      "--state <state>",
+      "Filter by state (opened, closed, merged, locked, all)",
+      "opened"
+    )
+    .option(
+      "--scope <scope>",
+      "Filter by scope (created_by_me, assigned_to_me, all)"
+    )
+    .option("--author-id <id>", "Filter by author ID")
+    .option("--assignee-id <id>", "Filter by assignee ID")
+    .option("--reviewer-id <id>", "Filter by reviewer ID")
+    .option("-s, --search <query>", "Search in title and description")
+    .option("-l, --labels <labels>", "Filter by labels (comma-separated)")
+    .option("--created-after <date>", "Filter by created date (ISO 8601)")
+    .option("--created-before <date>", "Filter by created date (ISO 8601)")
+    .option("--updated-after <date>", "Filter by updated date (ISO 8601)")
+    .option("--updated-before <date>", "Filter by updated date (ISO 8601)")
+    .option("--order-by <field>", "Order by field (created_at, updated_at)")
+    .option("--sort <direction>", "Sort direction (asc, desc)")
+    .option("--per-page <count>", "Number of results per page", "20")
+    .option("--page <number>", "Page number", "1")
+    .option("--json", "Output as JSON")
+    .action(async (options: MergeRequestsCommandOptions) => {
+      try {
+        const client = createClientFromEnv();
+
+        const listOptions: MergeRequestListOptions = {
+          projectId: options.project,
+          state: options.state,
+          scope: options.scope,
+          authorId: options.authorId ? parseInt(options.authorId, 10) : undefined,
+          assigneeId: options.assigneeId
+            ? parseInt(options.assigneeId, 10)
+            : undefined,
+          reviewerId: options.reviewerId
+            ? parseInt(options.reviewerId, 10)
+            : undefined,
+          search: options.search,
+          labels: options.labels ? options.labels.split(",").map((l) => l.trim()) : undefined,
+          createdAfter: options.createdAfter,
+          createdBefore: options.createdBefore,
+          updatedAfter: options.updatedAfter,
+          updatedBefore: options.updatedBefore,
+          orderBy: options.orderBy as MergeRequestListOptions["orderBy"],
+          sort: options.sort,
+          perPage: options.perPage ? parseInt(options.perPage, 10) : undefined,
+          page: options.page ? parseInt(options.page, 10) : undefined,
+        };
+
+        const mergeRequests = await client.listMergeRequests(listOptions);
+
+        if (options.json) {
+          console.log(JSON.stringify(mergeRequests, null, 2));
+        } else {
+          if (mergeRequests.length === 0) {
+            console.log("No merge requests found.");
+            return;
+          }
+
+          const projectInfo = options.project
+            ? ` for project: ${options.project}`
+            : "";
+          console.log(
+            `Found ${mergeRequests.length} merge request(s)${projectInfo}:\n`
+          );
+
+          mergeRequests.forEach((mr, index) => {
+            console.log(`--- MR ${index + 1} ---`);
+            console.log(formatMergeRequest(mr));
+            console.log("");
+          });
+        }
+      } catch (error) {
+        console.error(
+          "Error:",
+          error instanceof Error ? error.message : String(error)
+        );
+        process.exit(1);
+      }
+    });
+}

--- a/gitlab-api-tool/src/commands/projects.ts
+++ b/gitlab-api-tool/src/commands/projects.ts
@@ -1,0 +1,102 @@
+/**
+ * Projects Command
+ */
+
+import type { Command } from "commander";
+import { createClientFromEnv } from "../client/index.js";
+import type { ProjectListOptions, GitLabProject } from "../types/index.js";
+
+interface ProjectsCommandOptions {
+  owned?: boolean;
+  membership?: boolean;
+  starred?: boolean;
+  search?: string;
+  visibility?: "private" | "internal" | "public";
+  archived?: boolean;
+  orderBy?: string;
+  sort?: "asc" | "desc";
+  perPage?: string;
+  page?: string;
+  json?: boolean;
+}
+
+function formatProject(project: GitLabProject): string {
+  const lines = [
+    `ID: ${project.id}`,
+    `Name: ${project.name_with_namespace}`,
+    `Path: ${project.path_with_namespace}`,
+    `URL: ${project.web_url}`,
+    `Visibility: ${project.visibility}`,
+    `Default Branch: ${project.default_branch}`,
+    `Description: ${project.description ?? "(no description)"}`,
+    `Stars: ${project.star_count} | Forks: ${project.forks_count} | Issues: ${project.open_issues_count}`,
+    `Last Activity: ${project.last_activity_at}`,
+    `Archived: ${project.archived ? "Yes" : "No"}`,
+  ];
+  return lines.join("\n");
+}
+
+export function registerProjectsCommand(program: Command): void {
+  program
+    .command("projects")
+    .description("List GitLab projects")
+    .option("--owned", "List only projects owned by the authenticated user")
+    .option("--membership", "List only projects the user is a member of")
+    .option("--starred", "List only starred projects")
+    .option("-s, --search <query>", "Search projects by name")
+    .option(
+      "-v, --visibility <visibility>",
+      "Filter by visibility (private, internal, public)"
+    )
+    .option("--archived", "Include archived projects")
+    .option(
+      "--order-by <field>",
+      "Order by field (id, name, path, created_at, updated_at, last_activity_at)"
+    )
+    .option("--sort <direction>", "Sort direction (asc, desc)")
+    .option("--per-page <count>", "Number of results per page", "20")
+    .option("--page <number>", "Page number", "1")
+    .option("--json", "Output as JSON")
+    .action(async (options: ProjectsCommandOptions) => {
+      try {
+        const client = createClientFromEnv();
+
+        const listOptions: ProjectListOptions = {
+          owned: options.owned,
+          membership: options.membership,
+          starred: options.starred,
+          search: options.search,
+          visibility: options.visibility,
+          archived: options.archived,
+          orderBy: options.orderBy as ProjectListOptions["orderBy"],
+          sort: options.sort,
+          perPage: options.perPage ? parseInt(options.perPage, 10) : undefined,
+          page: options.page ? parseInt(options.page, 10) : undefined,
+        };
+
+        const projects = await client.listProjects(listOptions);
+
+        if (options.json) {
+          console.log(JSON.stringify(projects, null, 2));
+        } else {
+          if (projects.length === 0) {
+            console.log("No projects found.");
+            return;
+          }
+
+          console.log(`Found ${projects.length} project(s):\n`);
+          projects.forEach((project, index) => {
+            console.log(`--- Project ${index + 1} ---`);
+            console.log(formatProject(project));
+            console.log("");
+          });
+        }
+      } catch (error) {
+        console.error(
+          "Error:",
+          error instanceof Error ? error.message : String(error)
+        );
+        process.exit(1);
+      }
+    });
+}

--- a/gitlab-api-tool/src/index.ts
+++ b/gitlab-api-tool/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * GitLab API Tool - Library Entry Point
+ */
+
+export { GitLabClient, createClientFromEnv } from "./client/index.js";
+export type {
+  GitLabConfig,
+  GitLabProject,
+  GitLabUser,
+  GitLabMergeRequest,
+  ProjectListOptions,
+  MergeRequestListOptions,
+} from "./types/index.js";

--- a/gitlab-api-tool/src/types/index.ts
+++ b/gitlab-api-tool/src/types/index.ts
@@ -1,0 +1,101 @@
+/**
+ * GitLab API Types
+ */
+
+export interface GitLabConfig {
+  baseUrl: string;
+  privateToken: string;
+}
+
+export interface GitLabProject {
+  id: number;
+  name: string;
+  name_with_namespace: string;
+  path: string;
+  path_with_namespace: string;
+  description: string | null;
+  web_url: string;
+  ssh_url_to_repo: string;
+  http_url_to_repo: string;
+  default_branch: string;
+  visibility: "private" | "internal" | "public";
+  created_at: string;
+  last_activity_at: string;
+  archived: boolean;
+  star_count: number;
+  forks_count: number;
+  open_issues_count: number;
+  namespace: {
+    id: number;
+    name: string;
+    path: string;
+    kind: string;
+    full_path: string;
+  };
+}
+
+export interface GitLabUser {
+  id: number;
+  username: string;
+  name: string;
+  state: string;
+  avatar_url: string;
+  web_url: string;
+}
+
+export interface GitLabMergeRequest {
+  id: number;
+  iid: number;
+  title: string;
+  description: string | null;
+  state: "opened" | "closed" | "merged" | "locked";
+  created_at: string;
+  updated_at: string;
+  merged_at: string | null;
+  closed_at: string | null;
+  source_branch: string;
+  target_branch: string;
+  web_url: string;
+  author: GitLabUser;
+  assignee: GitLabUser | null;
+  assignees: GitLabUser[];
+  reviewers: GitLabUser[];
+  draft: boolean;
+  work_in_progress: boolean;
+  merge_status: string;
+  has_conflicts: boolean;
+  labels: string[];
+  project_id: number;
+}
+
+export interface ProjectListOptions {
+  owned?: boolean;
+  membership?: boolean;
+  starred?: boolean;
+  search?: string;
+  visibility?: "private" | "internal" | "public";
+  archived?: boolean;
+  orderBy?: "id" | "name" | "path" | "created_at" | "updated_at" | "last_activity_at";
+  sort?: "asc" | "desc";
+  perPage?: number;
+  page?: number;
+}
+
+export interface MergeRequestListOptions {
+  projectId?: number | string;
+  state?: "opened" | "closed" | "merged" | "locked" | "all";
+  scope?: "created_by_me" | "assigned_to_me" | "all";
+  authorId?: number;
+  assigneeId?: number;
+  reviewerId?: number;
+  search?: string;
+  labels?: string[];
+  createdAfter?: string;
+  createdBefore?: string;
+  updatedAfter?: string;
+  updatedBefore?: string;
+  orderBy?: "created_at" | "updated_at";
+  sort?: "asc" | "desc";
+  perPage?: number;
+  page?: number;
+}

--- a/gitlab-api-tool/tsconfig.json
+++ b/gitlab-api-tool/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Implements a TypeScript CLI tool that uses GitLab Web API to:
- List projects with filtering options (owned, membership, search, visibility)
- List merge requests with filtering (state, scope, labels, dates)
- Support JSON output for scripting
- Can also be used as a library